### PR TITLE
Optionally create gateway SREB-1081

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # Module directory
 .terraform/
+
+# editors
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,11 @@ RUN apt-get update && \
 
 COPY files/entrypoint.sh /bin/entrypoint.sh
 
+ARG GIT_COMMIT_SHA
+ENV GIT_COMMIT_SHA ${GIT_COMMIT_SHA}
+
+RUN echo $GIT_COMMIT_SHA > built-from-git-commit-sha
+
 ENTRYPOINT ["/tini", "--"]
 # Run your program under Tini
 CMD ["entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@ FROM quay.io/sdmrepo/relay
 ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
+
+RUN apt-get update && \
+  apt-get install -y curl && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/
+
 COPY files/entrypoint.sh /bin/entrypoint.sh
 
 ENTRYPOINT ["/tini", "--"]

--- a/ecs.tf
+++ b/ecs.tf
@@ -20,6 +20,7 @@ data "template_file" "container_definition" {
     awslogs_group         = "${var.service_identifier}-${var.task_identifier}"
     awslogs_region        = "${data.aws_region.region.name}"
     awslogs_stream_prefix = "${var.service_identifier}"
+    app_port              = "${var.sdm_gateway_listen_app_port}"
   }
 }
 

--- a/ecs.tf
+++ b/ecs.tf
@@ -64,3 +64,13 @@ resource "aws_cloudwatch_log_group" "task" {
   name              = "${var.service_identifier}-${var.task_identifier}"
   retention_in_days = "${var.ecs_log_retention}"
 }
+
+resource "aws_security_group_rule" "gateway_inbound_traffic" {
+  count             = "${var.enable_sdm_gateway == "true" ? 1 : 0}"
+  from_port         = "${var.sdm_gateway_listen_app_port}"
+  protocol          = "tcp"
+  security_group_id = "${var.ecs_cluster_extra_access_sg_id}"
+  to_port           = "${var.sdm_gateway_listen_app_port}"
+  type              = "ingress"
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/files/container_definition.json
+++ b/files/container_definition.json
@@ -25,7 +25,7 @@
         "portMappings": [
             {
                 "containerPort": ${app_port},
-                "hostPort": 0,
+                "hostPort": ${app_port},
                 "protocol": "tcp"
             }
         ]

--- a/files/container_definition.json
+++ b/files/container_definition.json
@@ -21,6 +21,13 @@
                "awslogs-region": "${awslogs_region}",
                "awslogs-stream-prefix": "${awslogs_stream_prefix}"
             }
-        }
+        },
+        "portMappings": [
+            {
+                "containerPort": ${app_port},
+                "hostPort": 0,
+                "protocol": "tcp"
+            }
+        ]
     }
 ]

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -19,10 +19,8 @@ if [[ "${ENABLE_SDM_GATEWAY}" == "true" ]] ; then \
   PUBLIC_IP=$(eval "$CURL_METADATA_COMMAND")
   echo "found public IP $PUBLIC_IP"
   CREATE_GATEWAY_TOKEN_COMMAND="$CMD relay create-gateway ${PUBLIC_IP}:${SDM_GATEWAY_LISTEN_APP_PORT} 0.0.0.0:${SDM_GATEWAY_LISTEN_APP_PORT}"
-  echo "would have run: $CREATE_GATEWAY_TOKEN_COMMAND"
-  #export SDM_RELAY_TOKEN=$(eval "$CREATE_GATEWAY_TOKEN_COMMAND")
-  echo "sleeping 60000 because that was commented out"
-  sleep 60000
+  echo "running: $CREATE_GATEWAY_TOKEN_COMMAND"
+  export SDM_RELAY_TOKEN=$(eval "$CREATE_GATEWAY_TOKEN_COMMAND")
 fi
 
 # temporary auth state is created by invoking `relay create` and must

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -18,7 +18,7 @@ if [[ "${ENABLE_SDM_GATEWAY}" == "true" ]] ; then \
   echo $CURL_METADATA_COMMAND
   PUBLIC_IP=$(eval "$CURL_METADATA_COMMAND")
   echo "found public IP $PUBLIC_IP"
-  CREATE_GATEWAY_TOKEN_COMMAND="$CMD relay create-gateway 0.0.0.0:${SDM_GATEWAY_LISTEN_APP_PORT} ${PUBLIC_IP}:${SDM_GATEWAY_LISTEN_APP_PORT}"
+  CREATE_GATEWAY_TOKEN_COMMAND="$CMD relay create-gateway ${PUBLIC_IP}:${SDM_GATEWAY_LISTEN_APP_PORT} 0.0.0.0:${SDM_GATEWAY_LISTEN_APP_PORT}"
   echo "would have run: $CREATE_GATEWAY_TOKEN_COMMAND"
   #export SDM_RELAY_TOKEN=$(eval "$CREATE_GATEWAY_TOKEN_COMMAND")
   echo "sleeping 60000 because that was commented out"

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -2,11 +2,28 @@
 
 CMD=/sdm.linux
 
+CURL_METADATA_TIMEOUT=${CURL_METADATA_TIMEOUT:-30}
+
 # necessary to suppress stdout during token create
 unset SDM_DOCKERIZED
 
 # generate fresh relay token (depends on inheriting SDM_ADMIN_TOKEN)
-export SDM_RELAY_TOKEN=`$CMD relay create`
+if [[ "${ENABLE_SDM_GATEWAY}" == "false" ]] ; then \
+  export SDM_RELAY_TOKEN=`$CMD relay create`
+fi
+
+# if we're a gateway, get our public ip and then create a gateway token
+if [[ "${ENABLE_SDM_GATEWAY}" == "true" ]] ; then \
+  CURL_METADATA_COMMAND="curl --silent --max-time ${CURL_METADATA_TIMEOUT} http://169.254.169.254/latest/meta-data/public-ipv4"
+  echo $CURL_METADATA_COMMAND
+  PUBLIC_IP=$(eval "$CURL_METADATA_COMMAND")
+  echo "found public IP $PUBLIC_IP"
+  CREATE_GATEWAY_TOKEN_COMMAND="$CMD relay create-gateway 0.0.0.0:${SDM_GATEWAY_LISTEN_APP_PORT} ${PUBLIC_IP}:${SDM_GATEWAY_LISTEN_APP_PORT}"
+  echo "would have run: $CREATE_GATEWAY_TOKEN_COMMAND"
+  #export SDM_RELAY_TOKEN=$(eval "$CREATE_GATEWAY_TOKEN_COMMAND")
+  echo "sleeping 60000 because that was commented out"
+  sleep 60000
+fi
 
 # temporary auth state is created by invoking `relay create` and must
 # be cleared out prior to relay startup

--- a/main.tf
+++ b/main.tf
@@ -10,11 +10,19 @@ locals {
   docker_environment = [
     {
       "name"  = "SERVICE_NAME"
-      "value" = "strongdm-relay"
+      "value" = "strongdm-${var.enable_sdm_gateway == "true" ? "gateway" : "relay"}"
     },
     {
       "name"  = "SDM_ADMIN_TOKEN"
       "value" = "${var.sdm_admin_token}"
+    },
+    {
+      "name"  = "ENABLE_SDM_GATEWAY"
+      "value" = "${var.enable_sdm_gateway}"
+    },
+    {
+      "name"  = "SDM_GATEWAY_LISTEN_APP_PORT"
+      "value" = "${var.sdm_gateway_listen_app_port}"
     },
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -133,3 +133,8 @@ variable "curl_metadata_timeout" {
   description = "Time in seconds to time out the curl for EC2 metadata"
   default     = 30
 }
+
+variable "ecs_cluster_extra_access_sg_id" {
+  description = "ECS extra access Security Group ID to attach a security_group_rule to for strongdm gateway inbound traffic. Note cannot contain inline rule blocks."
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -118,3 +118,18 @@ variable "ecs_log_retention" {
   description = "Number of days of ECS task logs to retain (default 3)"
   default     = 3
 }
+
+variable "enable_sdm_gateway" {
+  description = "Should the sdm relay also be a gateway? default false"
+  default     = false
+}
+
+variable "sdm_gateway_listen_app_port" {
+  description = "Port for SDM gateway to listen on inside container"
+  default     = 5000
+}
+
+variable "curl_metadata_timeout" {
+  description = "Time in seconds to time out the curl for EC2 metadata"
+  default     = 30
+}

--- a/variables.tf
+++ b/variables.tf
@@ -121,7 +121,7 @@ variable "ecs_log_retention" {
 
 variable "enable_sdm_gateway" {
   description = "Should the sdm relay also be a gateway? default false"
-  default     = false
+  default     = "false"
 }
 
 variable "sdm_gateway_listen_app_port" {


### PR DESCRIPTION
This adds a flag to optionally have the strongdm relay also be a gateway. Run this on an ECS cluster where the instances get public IPs. If not setting that flag, previous behavior is maintained.